### PR TITLE
Increase Sentry installation hook timeout.

### DIFF
--- a/templates/sentry_values.yaml
+++ b/templates/sentry_values.yaml
@@ -61,3 +61,5 @@ slack:
   signingSecret: "${sentry_slack_signing_secret}"
 %{ endif ~}
 
+hooks:
+  activeDeadlineSeconds: 600


### PR DESCRIPTION
The default timeout is 100 seconds, which is a little bit too short leading to Terraform error during installation.  This change is to overwrite it with 600 seconds.