### PR TITLE
Enable auto-purge for Clickhouse's zookeeper instances

### DIFF
--- a/templates/sentry_values.yaml
+++ b/templates/sentry_values.yaml
@@ -28,6 +28,13 @@ relay:
 ingress:
   enabled: false
 
+zookeeper:
+  autopurge:
+    purgeInterval: 6
+    snapRetainCount: 3
+  persistence:
+    size: 30Gi
+
 postgresql:
   enabled: false
 


### PR DESCRIPTION
By default, in Sentry Helm chart 20.5.3, clickhouse's zookeeper instances have auto-purge disabled

<img width="1667" alt="Screenshot 2024-10-29 at 6 07 18 PM" src="https://github.com/user-attachments/assets/d1eba00c-f22a-4fc7-a795-c6c1001b0700">

and adds up snapshot and transaction log files overtime and we would have to manually delete those

we have to enable the auto-purge to automatically delete the old snapshots and log files